### PR TITLE
Use testRunId to identify test reports

### DIFF
--- a/src/main/scala/com/gu/support/tstash/TstashAppender.scala
+++ b/src/main/scala/com/gu/support/tstash/TstashAppender.scala
@@ -20,10 +20,10 @@ class TstashAppender extends UnsynchronizedAppenderBase[ILoggingEvent] {
 
   override def append(eventObject: ILoggingEvent): Unit = {
     val failed = """(?s)\[FAILED\](.*)""".r
-    val urlExtractor = """(?s)\[URL\](.*)""".r
+    val urlExtractor = """(?s)\[StartInfo\](.*) (.*)""".r
 
     eventObject.getMessage match {
-      case urlExtractor(url) => sendHTMLFile(url)
+      case urlExtractor(url, testId) => sendHTMLFile(url, testId)
       case failed(m) => sendError(eventObject, m)
       case "[SCREENSHOT]" => sendScreenShot(eventObject)
       case _ => sendMessage(eventObject)
@@ -64,9 +64,9 @@ class TstashAppender extends UnsynchronizedAppenderBase[ILoggingEvent] {
     }
   }
 
-  def sendHTMLFile(tstashURL: String): Unit = {
+  def sendHTMLFile(tstashURL: String, testId: String): Unit = {
     val tstashReportHtml = s"<html><head><meta <meta http-equiv='refresh' content='0; url=$tstashURL' /></head><body><a href='$tstashURL'>Test report</a></body></html>"
-    Files.write(Paths.get("TstashReport.html"), tstashReportHtml.getBytes(StandardCharsets.UTF_8))
+    Files.write(Paths.get(s"TstashReport-$testId.html"), tstashReportHtml.getBytes(StandardCharsets.UTF_8))
   }
 
   private def sendScreenShot(eventObject: ILoggingEvent): Unit = {

--- a/src/main/scala/com/gu/support/tstash/TstashAppender.scala
+++ b/src/main/scala/com/gu/support/tstash/TstashAppender.scala
@@ -66,7 +66,13 @@ class TstashAppender extends UnsynchronizedAppenderBase[ILoggingEvent] {
 
   def sendHTMLFile(tstashURL: String, testId: String): Unit = {
     val tstashReportHtml = s"<html><head><meta <meta http-equiv='refresh' content='0; url=$tstashURL' /></head><body><a href='$tstashURL'>Test report</a></body></html>"
-    Files.write(Paths.get(s"TstashReport-$testId.html"), tstashReportHtml.getBytes(StandardCharsets.UTF_8))
+    if (testId.startsWith("Some")) {
+      val testIdCut = testId.drop(5).dropRight(1)
+      Files.write(Paths.get(s"TstashReport-$testIdCut.html"), tstashReportHtml.getBytes(StandardCharsets.UTF_8))
+    }
+    else {
+      Files.write(Paths.get(s"TstashReport.html"), tstashReportHtml.getBytes(StandardCharsets.UTF_8))
+    }
   }
 
   private def sendScreenShot(eventObject: ILoggingEvent): Unit = {

--- a/src/main/scala/com/gu/support/tstash/TstashAppender.scala
+++ b/src/main/scala/com/gu/support/tstash/TstashAppender.scala
@@ -19,14 +19,25 @@ object TstashAppender {
 class TstashAppender extends UnsynchronizedAppenderBase[ILoggingEvent] {
 
   override def append(eventObject: ILoggingEvent): Unit = {
-    val failed = """(?s)\[FAILED\](.*)""".r
-    val urlExtractor = """(?s)\[StartInfo\](.*) (.*)""".r
+    prepareMessageReaction(eventObject) match {
+      case Some((name, content)) => Files.write(Paths.get(name), content.getBytes(StandardCharsets.UTF_8))
+    }
+  }
 
-    eventObject.getMessage match {
-      case urlExtractor(url, testId) => sendHTMLFile(url, testId)
-      case failed(m) => sendError(eventObject, m)
-      case "[SCREENSHOT]" => sendScreenShot(eventObject)
-      case _ => sendMessage(eventObject)
+  def prepareMessageReaction(eventObject: ILoggingEvent): Option[(String, String)] ={
+    val failed = """(?s)\[FAILED\](.*)""".r
+    val urlExtractor = """(?s)\[StartInfo\](.+) (.+)""".r
+    val urlExtractorWithNoName = """(?s)\[StartInfo\](.*)""".r
+
+    eventObject.getMessage() match {
+      case urlExtractor(url, testId) => Some(sendHTMLFile(url, Some(testId)))
+      case urlExtractorWithNoName(url) => Some(sendHTMLFile(url, None))
+      case failed(m) => {sendError(eventObject, m)
+        None}
+      case "[SCREENSHOT]" => {sendScreenShot(eventObject)
+        None}
+      case _ => {sendMessage(eventObject)
+        None}
     }
   }
 
@@ -64,15 +75,17 @@ class TstashAppender extends UnsynchronizedAppenderBase[ILoggingEvent] {
     }
   }
 
-  def sendHTMLFile(tstashURL: String, testId: String): Unit = {
+  def sendHTMLFile(tstashURL: String, testId: Option[String]): (String, String) = {
     val tstashReportHtml = s"<html><head><meta <meta http-equiv='refresh' content='0; url=$tstashURL' /></head><body><a href='$tstashURL'>Test report</a></body></html>"
-    if (testId.startsWith("Some")) {
-      val testIdCut = testId.drop(5).dropRight(1)
-      Files.write(Paths.get(s"TstashReport-$testIdCut.html"), tstashReportHtml.getBytes(StandardCharsets.UTF_8))
+    (generateHTMLFileName(tstashURL, testId),tstashReportHtml)
+  }
+
+  def generateHTMLFileName(tstashURL: String, testId: Option[String]): String = {
+    val filename = testId match {
+      case Some(testId) => s"TstashReport-$testId.html"
+      case None => "TstashReport.html"
     }
-    else {
-      Files.write(Paths.get(s"TstashReport.html"), tstashReportHtml.getBytes(StandardCharsets.UTF_8))
-    }
+    filename
   }
 
   private def sendScreenShot(eventObject: ILoggingEvent): Unit = {

--- a/src/test/scala/com/gu/support/tstash/TstashAppenderTest.scala
+++ b/src/test/scala/com/gu/support/tstash/TstashAppenderTest.scala
@@ -1,13 +1,19 @@
 package com.gu.automation.api
 
+import java.util
 import java.util.UUID
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.{LoggerContextVO, IThrowableProxy, ILoggingEvent}
+import com.gu.support.tstash.TstashAppender
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.joda.time.DateTime
 import org.openqa.selenium.OutputType
 import org.openqa.selenium.firefox.FirefoxDriver
 import org.scalatest._
-import org.slf4j.MDC
+import org.slf4j.{Marker, MDC}
+
+import scala.None
 
 class TstashAppenderTest extends FlatSpec with Matchers with LazyLogging {
 
@@ -76,8 +82,60 @@ class TstashAppenderTest extends FlatSpec with Matchers with LazyLogging {
 //
 //  }
 
+  "TestInfo with testID" should "produce correct filename" in {
+    val eventObject = new eventObject("[StartInfo] www.test.com testId")
+    val appender = new TstashAppender
+    val message = appender.prepareMessageReaction(eventObject)
+    message shouldNot be (None)
+    message.get._2 shouldNot be ("")
+    message.get._1 shouldBe ("TstashReport-testId.html")
+  }
+
+  "TestInfo with no testId" should "produce correct filename" in {
+    val eventObject = new eventObject("[StartInfo] www.test.com ")
+    val appender = new TstashAppender
+    val message = appender.prepareMessageReaction(eventObject)
+    message shouldNot be (None)
+    message.get._2 shouldNot be ("")
+    message.get._1 shouldBe ("TstashReport.html")
+  }
+
 }
 
 object SetTime {
   val time = DateTime.now
+}
+
+case class eventObject(message: String) extends ILoggingEvent {
+
+  override def getThreadName: String = ???
+
+  override def getLoggerName: String = ???
+
+  override def getFormattedMessage: String = ???
+
+  override def getMessage: String = message
+
+  override def getLoggerContextVO: LoggerContextVO = ???
+
+  override def getLevel: Level = ???
+
+  override def getTimeStamp: Long = ???
+
+  override def getCallerData: Array[StackTraceElement] = ???
+
+  override def hasCallerData: Boolean = ???
+
+  override def getMDCPropertyMap: util.Map[String, String] = ???
+
+  override def getMdc: util.Map[String, String] = ???
+
+  override def getArgumentArray: Array[AnyRef] = ???
+
+  override def getMarker: Marker = ???
+
+  override def getThrowableProxy: IThrowableProxy = ???
+
+  override def prepareForDeferredProcessing(): Unit = ???
+
 }


### PR DESCRIPTION
We now pass an optional testRunId from Scala Automation. This is then added to the file name of the TstashReport.html (if present) so that we can distinguish between devices on the mobile apps automation parallel test runs

@jamesoram @johnduffell 
